### PR TITLE
Fix broken link in "Updating your PR" section

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -33,4 +33,4 @@ Thank you for your suggestion!
 
 ### Updating your PR
 
-A lot of times, making a PR adhere to the standards above can be difficult. If the maintainers notice anything that we'd like changed, we'll ask you to edit your PR before we merge it. There's no need to open a new PR, just edit the existing one. If you're not sure how to do that, [here is a guide](https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md) on the different ways you can update your PR so that we can merge it.
+A lot of times, making a PR adhere to the standards above can be difficult. If the maintainers notice anything that we'd like changed, we'll ask you to edit your PR before we merge it. There's no need to open a new PR, just edit the existing one. If you're not sure how to do that, [here is a guide](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) on the different ways you can update your PR so that we can merge it.


### PR DESCRIPTION
# Summary

Fixed broken `here is a guide` link in "Updating your PR" section.

## Problem

Current link URL `https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md` returns a "Page not found" GitHub error page.

## Solution

New link URL `https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md` returns the appropriate working page.


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
