### PR TITLE
Fix broken link: contribution guidelines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 This list is mainly about [CSS](https://developer.mozilla.org/docs/Web/CSS) – the language and the modules. Not about naming conventions, architecture paradigms, frameworks, pre-processors, post-processors, CSS-in-JS or other aspects of todays CSS ecosystem.
 
-*Please read the [contribution guidelines](.github/contributing.md) before contributing.*
+*Please read the [contribution guidelines](./contributing.md) before contributing.*
 
 ## Contents
 


### PR DESCRIPTION
# Summary

The "contribution guidelines" link in the page introduction section is broken.

## Problem

Current link URL `.github/contributing.md` returns a GitHub "Page not found" error page.

## Solution

New link URL `./contributing.md` returns the appropriate working page.


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
