### PR TITLE
Fix spelling of resource name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ This list is mainly about [CSS](https://developer.mozilla.org/docs/Web/CSS) – 
 
 - [Basic CSS Selectors](https://www.sitepoint.com/css-selectors/) - An introducing to the very basic CSS selectors you need to know.
 - [Advanced CSS Selectors](https://www.smashingmagazine.com/2009/08/taming-advanced-css-selectors/) - Level up your knowledge. From attribute selectors to CSS3 pseudo classes.
-- [CSS Dinner](https://flukeout.github.io) - Learn how to use CSS selectors with this fun little game.
+- [CSS Diner](https://flukeout.github.io) - Learn how to use CSS selectors with this fun little game.
 
 ## Custom properties (aka CSS variables)
 


### PR DESCRIPTION
# Summary

The `CSS Dinner` resource should be spelled `CSS Diner` in the `Selectors` section.

## Problem

`CSS Dinner` is the incorrect spelling of the resource in the `Selectors` section.

## Solution

`CSS Diner` is the correct spelling of the resource in the `Selectors` section.


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
