### PR TITLE
Fix typo in "Animation" category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ This list is mainly about [CSS](https://developer.mozilla.org/docs/Web/CSS) – 
 
 ## Animation
 
-- [CSS Transitions and Transforms for Beginners](https://robots.thoughtbot.com/transitions-and-transforms) - An introduction to to CSS transitions and CSS (2D) transforms.
+- [CSS Transitions and Transforms for Beginners](https://robots.thoughtbot.com/transitions-and-transforms) - An introduction to CSS transitions and CSS (2D) transforms.
 - [All you need to know about CSS Transitions](https://blog.alexmaccaw.com/all-you-need-to-know-about-css-transitions/) - Also addressing advanced topics from chaining and events to hardware acceleration and animation functions.
 - [CSS 3D transforms](https://3dtransforms.desandro.com) - Multi page tutorial with examples like card flip and carousel effects.
 - [CSS Animation for Beginners](https://robots.thoughtbot.com/css-animation-for-beginners) - Imparts the concepts of CSS animations with keyframes.


### PR DESCRIPTION
# Summary

The resource description for `CSS Transitions and Transforms for Beginners` in the "Animation" category has a typo.

## Problem

The sentence, `An introduction to to CSS transitions and CSS (2D) transforms.`, incorrectly has the double-word typo `to to`.

## Solution

The sentence should read, `An introduction to CSS transitions and CSS (2D) transforms.`, with only one `to` in it.


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
