### PR TITLE
Fix typo in "Basic CSS Selectors" description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ This list is mainly about [CSS](https://developer.mozilla.org/docs/Web/CSS) – 
 
 ## Selectors
 
-- [Basic CSS Selectors](https://www.sitepoint.com/css-selectors/) - An introducing to the very basic CSS selectors you need to know.
+- [Basic CSS Selectors](https://www.sitepoint.com/css-selectors/) - An introduction to the very basic CSS selectors you need to know.
 - [Advanced CSS Selectors](https://www.smashingmagazine.com/2009/08/taming-advanced-css-selectors/) - Level up your knowledge. From attribute selectors to CSS3 pseudo classes.
 - [CSS Diner](https://flukeout.github.io) - Learn how to use CSS selectors with this fun little game.
 


### PR DESCRIPTION
# Summary

In the resource description for "Basic CSS Selectors", the word `introducing` is incorrect and should be replaced with `introduction`.

## Problem

The sentence, `An introducing to the very basic CSS selectors you need to know.`, is incorrectly using the word `introducing`.

## Solution

The sentence should read, `An introduction to the very basic CSS selectors you need to know.`


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
