### PR TITLE
Fix typo in "Introduction to CSS" description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ This list is mainly about [CSS](https://developer.mozilla.org/docs/Web/CSS) – 
 
 ## CSS in a nutshell
 
-- [Introduction to CSS](https://scrimba.com/g/gintrotocss) - This Screencast series will teach you the basics of CSS in about one hour.
+- [Introduction to CSS](https://scrimba.com/g/gintrotocss) - This screencast series will teach you the basics of CSS in about one hour.
 
 ## Fundamental concepts
 


### PR DESCRIPTION
# Summary

In the resource description for "Introduction to CSS" in the "CSS in a nutshell" category, the word `Screencast` should not be capitalized.

## Problem

In the sentence, `This Screencast series will teach you the basics of CSS in about one hour.`, the word `Screencast` is incorrectly capitalized as a proper name.

## Solution

The sentence should read, `This screencast series will teach you the basics of CSS in about one hour.`


---

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-css-learning/blob/master/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point.
